### PR TITLE
Add / to beginning of dropbox file upload path

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -94,7 +94,7 @@ app.post('/makePack', async (req, res) => {
     // ----- UPLOAD THE ARCHIVE -----
     const fileID = nanoid(5);
 
-    const newPackPath = path.join('VanillaExtract/' + fileID + '.zip'); // New file upload path
+    const newPackPath = path.join('/VanillaExtract/' + fileID + '.zip'); // New file upload path
     
     // Log and upload when file has been made
     output.on('close', async () => {


### PR DESCRIPTION
In [my code](https://github.com/LittleImprovementsCustom/LittleImprovementsCustom/blob/2da567d05593fcc06466fd68e145f522c04c555b/app.js#L67), my file upload path with dbx.filesUpload began with a `/`. Not sure if this is the problem or not; not too familiar with `path.join()`